### PR TITLE
added encoding

### DIFF
--- a/process_data.py
+++ b/process_data.py
@@ -15,7 +15,7 @@ def build_data_cv(datafile, cv=10, clean_string=True):
     revs = []
     vocab = defaultdict(float)
 
-    with open(datafile, "rb") as csvf:
+    with open(datafile, "r", encoding = 'cp1252') as csvf:
         csvreader=csv.reader(csvf,delimiter=',',quotechar='"')
         first_line=True
         for line in csvreader:


### PR DESCRIPTION
The csv file needs to be opened with read(not binary) privileges. The value of encoding to use for opening this file is 'cp1252' on line 18. 
This change is based on my implementation in python 3.6+