### PR TITLE
Updating the read privileges in the open statement

### DIFF
--- a/process_data.py
+++ b/process_data.py
@@ -15,7 +15,7 @@ def build_data_cv(datafile, cv=10, clean_string=True):
     revs = []
     vocab = defaultdict(float)
 
-    with open(datafile, "rb") as csvf:
+    with open(datafile, "r", encoding = 'cp1252') as csvf:
         csvreader=csv.reader(csvf,delimiter=',',quotechar='"')
         first_line=True
         for line in csvreader:


### PR DESCRIPTION
In python 3+, you need to open the .csv file as a read-only privilege with the encoding of cp1252 or else the code won't work properly.