### PR TITLE
Updated line 438 to open instead of file

### DIFF
--- a/conv_net_classes.py
+++ b/conv_net_classes.py
@@ -13,7 +13,8 @@ import numpy
 import theano.tensor.shared_randomstreams
 import theano
 import theano.tensor as T
-from theano.tensor.signal import downsample
+# from theano.tensor.signal import downsample
+from theano.tensor.signal import pool
 from theano.tensor.nnet import conv
 
 def ReLU(x):

--- a/conv_net_train.py
+++ b/conv_net_train.py
@@ -435,7 +435,7 @@ if __name__=="__main__":
 
     r = range(0,10)
 
-    ofile=file('perf_output_'+str(attr)+'.txt','w')
+    ofile=open('perf_output_'+str(attr)+'.txt','w')
 
     charged_words=[]
 


### PR DESCRIPTION
file function has been deprecated in python 3. To write to a file, you need to use open function. It has the same syntax as file.